### PR TITLE
#5 Added a command line help argument and added a command line port argument for specifying a specific port for Counts to run on.

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,13 +4,18 @@ import (
 	"counts/counters"
 	"counts/server"
 	"counts/utils"
+	"flag"
 )
 
 var logger = utils.GetLogger()
 
 func main() {
+	var port = flag.String("p", "7596", "specifies the port for Counts to run on")
+	flag.Parse()
+
 	logger.Info.Println("Starting counts...")
 	manager := counters.GetManager()
 	server := server.New(manager)
-	server.Run()
+
+	server.Run(*port)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -125,9 +125,9 @@ func (srv *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 /*
 Run ...
 */
-func (srv *Server) Run() {
-	logger.Info.Println("Server up and running at :7596...")
-	http.ListenAndServe(":7596", srv)
+func (srv *Server) Run(port string) {
+	logger.Info.Println("Server up and running on port :" + port + " ...")
+	http.ListenAndServe(":"+port, srv)
 }
 
 /*


### PR DESCRIPTION
Counts can now take command line arguments:

Counts is a domain-counter data store

Usage:

	go run main.go [arguments]

The commands are:

	-p <port>	specifies a specific port for Counts to run on